### PR TITLE
fix: remove leaderkey timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ spoon.Vimnav
  :configure({
   leader = {
    key = " ", -- space
-   timeout = 0.5,
   },
 
   scroll = {
@@ -413,12 +412,13 @@ spoon.Vimnav:configure({
  hints = {
   depth = 15, -- Max element depth (lower = faster)
  },
- focusCheckInterval = 0.2, -- Focus detection frequency
+ focus = {
+  checkInterval = 0.2, -- Focus detection frequency
+ },
  scroll = {
   smoothScrollFramerate = 60, -- Lower FPS for less CPU
  },
 })
-
 ```
 
 ## 🎮 Available Commands
@@ -464,7 +464,6 @@ spoon.Vimnav:getDefaultConfig()          -- Returns default config
  -- Leader key
  leader = {
   key = " ", -- space
-  timeout = 0.5,
  },
 
  -- Link Hints
@@ -483,8 +482,10 @@ spoon.Vimnav:getDefaultConfig()          -- Returns default config
   },
  },
 
- -- Timing
- focusCheckInterval = 0.1,
+ -- Focus Manager
+ focus = {
+  checkInterval = 0.1,
+ },
 
  -- Keybindings
  mapping = {
@@ -593,7 +594,7 @@ spoon.Vimnav:getDefaultConfig()          -- Returns default config
 **Try these optimizations:**
 
 - Reduce element depth: `depth = 10`
-- Increase check interval: `focusCheckInterval = 0.3`
+- Increase check interval: `focus.checkInterval = 0.3`
 - Disable smooth scrolling: `scroll.smoothScroll = false`
 - Exclude problematic apps
 


### PR DESCRIPTION
After some usage, I think timeout is not required, as in most normal
mode, we dont need any passthrough for the leaderkey. This prevents the
issue where need to press really fast with the keys.

Now we can take our sweet time to press keys after <leader> and also
pressing `esc` key will just cancel or reset the <leader> and any other
characters
